### PR TITLE
Implemented Search Fragment and Added Explore Page

### DIFF
--- a/src/app/src/main/java/com/example/bookmark/BorrowedActivity.java
+++ b/src/app/src/main/java/com/example/bookmark/BorrowedActivity.java
@@ -14,6 +14,7 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.example.bookmark.adapters.BookList;
+import com.example.bookmark.fragments.SearchDialogFragment;
 import com.example.bookmark.models.Book;
 import com.example.bookmark.models.Owner;
 import com.example.bookmark.models.Request;
@@ -29,7 +30,7 @@ import java.util.ArrayList;
  *
  * @author Ryan Kortbeek.
  */
-public class BorrowedActivity extends AppCompatActivity {
+public class BorrowedActivity extends AppCompatActivity implements SearchDialogFragment.OnFragmentInteractionListener {
 
     ArrayList<Book> borrowedBooks;
     BookList borrowedBooksAdapter;
@@ -91,9 +92,25 @@ public class BorrowedActivity extends AppCompatActivity {
 
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == R.id.menu_filter_search_search_btn) {
-            // TODO open search fragment
-            ;
+            // Opens search fragment
+            new SearchDialogFragment().show(getSupportFragmentManager(),
+                "SEARCH_AVAILABLE_BOOKS");
         }
         return (super.onOptionsItemSelected(item));
+    }
+
+    @Override
+    public void executeSearch(String searchString) {
+        // TODO call search method from singleton that interacts with firebase
+
+        Intent intent = new Intent(BorrowedActivity.this, ExploreActivity.class);
+        // TODO put books that match the searched keyword(s) into intent that
+        //  is sent to the ExploreActivity which will display the search
+        //  results
+
+        // Proof of concept
+        intent.putExtra("proof", "Intent has been received!");
+
+        startActivity(intent);
     }
 }

--- a/src/app/src/main/java/com/example/bookmark/ExploreActivity.java
+++ b/src/app/src/main/java/com/example/bookmark/ExploreActivity.java
@@ -1,18 +1,105 @@
 package com.example.bookmark;
 
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.Parcelable;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ListView;
+
+import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 
-import android.os.Bundle;
+import com.example.bookmark.adapters.BookList;
+import com.example.bookmark.models.Book;
+import com.example.bookmark.models.Owner;
+import com.example.bookmark.models.Request;
+
+import java.util.ArrayList;
 
 /**
- * TODO: Description of class.
+ * This activity shows a user a list of books that match the keyword(s) from
+ * the search they have just performed. They can select a book which takes them
+ * to the ExploreBookDetailsActivity where they can see the books details.
+ * TODO what else do we want here?
+ *
  * @author Ryan Kortbeek.
  */
 public class ExploreActivity extends AppCompatActivity {
+
+    ArrayList<Book> searchResults;
+    BookList searchResultsAdapter;
+    ListView searchResultsListView;
+
+    ActionBar exploreActionBar;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_explore);
+
+        exploreActionBar = getSupportActionBar();
+        assert exploreActionBar != null;
+        exploreActionBar.setTitle("Explore");
+
+        searchResultsListView = findViewById(R.id.search_results_listview);
+
+        searchResults = new ArrayList<>();
+        getSearchResults();
+        searchResultsAdapter = new BookList(this, searchResults, true, true);
+        searchResultsListView.setAdapter(searchResultsAdapter);
+        searchResultsListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+            @Override
+            public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
+                Intent intent = new Intent(ExploreActivity.this,
+                    ExploreBookDetailsActivity.class);
+                // TODO decide how the book data is to be sent to the
+                //  ExploreBookDetailsActivity
+                intent.putExtra("selected-book",
+                    (Parcelable) searchResults.get(i));
+                startActivity(intent);
+            }
+        });
+    }
+
+    private void getSearchResults() {
+        // TODO get books from intent that match the searched keyword(s) -
+        //  this should be passed from the activity that started this
+        //  activity (i.e. the class that implements the executeSearch(..)
+        //  function from the interface in the SearchDialogFragment should
+        //  perform the search and pass the results to this activity)
+
+        // Proof of concept
+        Owner owner = new Owner("u", "fn", "ln",
+            "email", "pn",
+            new ArrayList<Book>(), new ArrayList<Request>());
+
+        Book b1 = new Book("Title 1", "Author 1", "1111111", owner);
+        b1.setDescription("Book 1 description");
+
+        searchResults.add(b1);
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        // Inflates the menu with the filter and search icons
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.menu_filter_search, menu);
+        return true;
+    }
+
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case R.id.menu_filter_search_search_btn:
+                // TODO open search fragment
+                break;
+            case R.id.menu_filter_search_filter_btn:
+                // TODO open filter fragment
+                break;
+        }
+        return (super.onOptionsItemSelected(item));
     }
 }

--- a/src/app/src/main/java/com/example/bookmark/ExploreActivity.java
+++ b/src/app/src/main/java/com/example/bookmark/ExploreActivity.java
@@ -14,6 +14,7 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.example.bookmark.adapters.BookList;
+import com.example.bookmark.fragments.SearchDialogFragment;
 import com.example.bookmark.models.Book;
 import com.example.bookmark.models.Owner;
 import com.example.bookmark.models.Request;
@@ -28,7 +29,7 @@ import java.util.ArrayList;
  *
  * @author Ryan Kortbeek.
  */
-public class ExploreActivity extends AppCompatActivity {
+public class ExploreActivity extends AppCompatActivity implements SearchDialogFragment.OnFragmentInteractionListener {
 
     ArrayList<Book> searchResults;
     BookList searchResultsAdapter;
@@ -48,7 +49,7 @@ public class ExploreActivity extends AppCompatActivity {
         searchResultsListView = findViewById(R.id.search_results_listview);
 
         searchResults = new ArrayList<>();
-        getSearchResults();
+        getSearchResults(getIntent());
         searchResultsAdapter = new BookList(this, searchResults, true, true);
         searchResultsListView.setAdapter(searchResultsAdapter);
         searchResultsListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
@@ -65,7 +66,7 @@ public class ExploreActivity extends AppCompatActivity {
         });
     }
 
-    private void getSearchResults() {
+    private void getSearchResults(Intent intent) {
         // TODO get books from intent that match the searched keyword(s) -
         //  this should be passed from the activity that started this
         //  activity (i.e. the class that implements the executeSearch(..)
@@ -73,14 +74,19 @@ public class ExploreActivity extends AppCompatActivity {
         //  perform the search and pass the results to this activity)
 
         // Proof of concept
-        Owner owner = new Owner("u", "fn", "ln",
-            "email", "pn",
-            new ArrayList<Book>(), new ArrayList<Request>());
+        Bundle bundle = intent.getExtras();
+        if (bundle != null) {
+            String proof = bundle.getString("proof");
 
-        Book b1 = new Book("Title 1", "Author 1", "1111111", owner);
-        b1.setDescription("Book 1 description");
+            Owner owner = new Owner("u", "fn", "ln",
+                "email", "pn",
+                new ArrayList<Book>(), new ArrayList<Request>());
 
-        searchResults.add(b1);
+            Book b1 = new Book("Title 1", "Author 1", "1111111", owner);
+            b1.setDescription(proof);
+
+            searchResults.add(b1);
+        }
     }
 
     @Override
@@ -94,12 +100,28 @@ public class ExploreActivity extends AppCompatActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.menu_filter_search_search_btn:
-                // TODO open search fragment
-                break;
+                // Opens search fragment
+                new SearchDialogFragment().show(getSupportFragmentManager(),
+                    "SEARCH_AVAILABLE_BOOKS");
             case R.id.menu_filter_search_filter_btn:
                 // TODO open filter fragment
                 break;
         }
         return (super.onOptionsItemSelected(item));
+    }
+
+    @Override
+    public void executeSearch(String searchString) {
+        // TODO call search method from singleton that interacts with firebase
+
+        Intent intent = new Intent(ExploreActivity.this, ExploreActivity.class);
+        // TODO put books that match the searched keyword(s) into intent that
+        //  is sent to the ExploreActivity which will display the search
+        //  results
+
+        // Proof of concept
+        intent.putExtra("proof", "Intent has been received!");
+
+        startActivity(intent);
     }
 }

--- a/src/app/src/main/java/com/example/bookmark/ExploreActivity.java
+++ b/src/app/src/main/java/com/example/bookmark/ExploreActivity.java
@@ -20,6 +20,7 @@ import com.example.bookmark.models.Owner;
 import com.example.bookmark.models.Request;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This activity shows a user a list of books that match the keyword(s) from
@@ -31,7 +32,7 @@ import java.util.ArrayList;
  */
 public class ExploreActivity extends AppCompatActivity implements SearchDialogFragment.OnFragmentInteractionListener {
 
-    ArrayList<Book> searchResults;
+    List<Book> searchResults = new ArrayList<>();
     BookList searchResultsAdapter;
     ListView searchResultsListView;
 
@@ -48,7 +49,6 @@ public class ExploreActivity extends AppCompatActivity implements SearchDialogFr
 
         searchResultsListView = findViewById(R.id.search_results_listview);
 
-        searchResults = new ArrayList<>();
         getSearchResults(getIntent());
         searchResultsAdapter = new BookList(this, searchResults, true, true);
         searchResultsListView.setAdapter(searchResultsAdapter);

--- a/src/app/src/main/java/com/example/bookmark/ExploreActivity.java
+++ b/src/app/src/main/java/com/example/bookmark/ExploreActivity.java
@@ -43,9 +43,7 @@ public class ExploreActivity extends AppCompatActivity implements SearchDialogFr
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_explore);
 
-        exploreActionBar = getSupportActionBar();
-        assert exploreActionBar != null;
-        exploreActionBar.setTitle("Explore");
+        getSupportActionBar().setTitle("Explore");
 
         searchResultsListView = findViewById(R.id.search_results_listview);
 

--- a/src/app/src/main/java/com/example/bookmark/MyBooksActivity.java
+++ b/src/app/src/main/java/com/example/bookmark/MyBooksActivity.java
@@ -11,6 +11,7 @@ import android.widget.ListView;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.example.bookmark.adapters.BookList;
+import com.example.bookmark.fragments.SearchDialogFragment;
 import com.example.bookmark.models.Book;
 import com.example.bookmark.models.Owner;
 import com.example.bookmark.models.Request;
@@ -28,7 +29,7 @@ import java.util.List;
  *
  * @author Mitch Adam.
  */
-public class MyBooksActivity extends AppCompatActivity {
+public class MyBooksActivity extends AppCompatActivity implements SearchDialogFragment.OnFragmentInteractionListener {
     // TODO: Figure out the back navigation
     // Going to need some sort of owner or uid
 
@@ -114,12 +115,28 @@ public class MyBooksActivity extends AppCompatActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.menu_filter_search_search_btn:
-                //TODO: Open search fragment
-                break;
+                // Opens search fragment
+                new SearchDialogFragment().show(getSupportFragmentManager(),
+                    "SEARCH_AVAILABLE_BOOKS");
             case R.id.menu_filter_search_filter_btn:
                 //TODO: Open filter fragment
                 break;
         }
         return (super.onOptionsItemSelected(item));
+    }
+
+    @Override
+    public void executeSearch(String searchString) {
+        // TODO call search method from singleton that interacts with firebase
+
+        Intent intent = new Intent(MyBooksActivity.this, ExploreActivity.class);
+        // TODO put books that match the searched keyword(s) into intent that
+        //  is sent to the ExploreActivity which will display the search
+        //  results
+
+        // Proof of concept
+        intent.putExtra("proof", "Intent has been received!");
+
+        startActivity(intent);
     }
 }

--- a/src/app/src/main/java/com/example/bookmark/PendingRequestsActivity.java
+++ b/src/app/src/main/java/com/example/bookmark/PendingRequestsActivity.java
@@ -14,6 +14,7 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.example.bookmark.adapters.BookList;
+import com.example.bookmark.fragments.SearchDialogFragment;
 import com.example.bookmark.models.Book;
 import com.example.bookmark.models.Owner;
 import com.example.bookmark.models.Request;
@@ -28,7 +29,7 @@ import java.util.ArrayList;
  *
  * @author Ryan Kortbeek.
  */
-public class PendingRequestsActivity extends AppCompatActivity {
+public class PendingRequestsActivity extends AppCompatActivity implements SearchDialogFragment.OnFragmentInteractionListener {
 
     ArrayList<Book> requestedBooks;
     BookList requestedBooksAdapter;
@@ -91,12 +92,28 @@ public class PendingRequestsActivity extends AppCompatActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.menu_filter_search_search_btn:
-                // TODO open search fragment
-                break;
+                // Opens search fragment
+                new SearchDialogFragment().show(getSupportFragmentManager(),
+                    "SEARCH_AVAILABLE_BOOKS");
             case R.id.menu_filter_search_filter_btn:
                 // TODO open filter fragment
                 break;
         }
         return (super.onOptionsItemSelected(item));
+    }
+
+    @Override
+    public void executeSearch(String searchString) {
+        // TODO call search method from singleton that interacts with firebase
+
+        Intent intent = new Intent(PendingRequestsActivity.this, ExploreActivity.class);
+        // TODO put books that match the searched keyword(s) into intent that
+        //  is sent to the ExploreActivity which will display the search
+        //  results
+
+        // Proof of concept
+        intent.putExtra("proof", "Intent has been received!");
+
+        startActivity(intent);
     }
 }

--- a/src/app/src/main/java/com/example/bookmark/fragments/SearchDialogFragment.java
+++ b/src/app/src/main/java/com/example/bookmark/fragments/SearchDialogFragment.java
@@ -1,4 +1,81 @@
 package com.example.bookmark.fragments;
 
-public class SearchDialogFragment {
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.Context;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.EditText;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
+
+import com.example.bookmark.R;
+
+/**
+ * Creates a fragment that allows the user to enter keywords and perform a
+ * search - note any class that uses this fragment must implement the
+ * OnFragmentInteractionListener interface (i.e. implement the
+ * executeSearch(..) function which should perform a search of the database in
+ * the desired way. The user is required to enter something in the search bar
+ * editText if they want to perform a search (if they have not entered
+ * anything and they try to press confirm the fragment will prompt them to do
+ * so.
+ *
+ * @author Ryan Kortbeek.
+ */
+public class SearchDialogFragment extends DialogFragment {
+    private EditText searchEditText;
+    private OnFragmentInteractionListener listener;
+
+    public interface OnFragmentInteractionListener {
+        void executeSearch(String searchString);
+    }
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        if (context instanceof OnFragmentInteractionListener) {
+            listener = (OnFragmentInteractionListener) context;
+        } else {
+            throw new RuntimeException(context.toString() + " must implement " +
+                "OnFragmentInteractionListener");
+        }
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        View view =
+            LayoutInflater.from(getActivity()).inflate(R.layout.fragment_search_dialog, null);
+        searchEditText = view.findViewById(R.id.search_bar_editText);
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
+        // Available books being all books that are not currently accepted or
+        // borrowed
+        builder.setView(view).setTitle("Search Available Books").setNegativeButton(
+            "CANCEL", null).setPositiveButton("CONFIRM", null);
+        final AlertDialog dialog = builder.create();
+        dialog.show();
+        dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                boolean proceed = Boolean.TRUE;
+                // There must be some text in the search bar to execute a search
+                if (TextUtils.isEmpty(searchEditText.getText())) {
+                    searchEditText.setError("Please enter the keywords that " +
+                        "you would like to search.");
+                    proceed = Boolean.FALSE;
+                }
+                if (proceed) {
+                    listener.executeSearch(searchEditText.getText().toString());
+                    dialog.dismiss();
+                }
+            }
+        });
+        return dialog;
+    }
 }

--- a/src/app/src/main/java/com/example/bookmark/fragments/SearchDialogFragment.java
+++ b/src/app/src/main/java/com/example/bookmark/fragments/SearchDialogFragment.java
@@ -68,7 +68,7 @@ public class SearchDialogFragment extends DialogFragment {
                 if (TextUtils.isEmpty(searchEditText.getText())) {
                     searchEditText.setError("Please enter the keywords that " +
                         "you would like to search.");
-                    proceed = Boolean.FALSE;
+                    proceed = false;
                 }
                 if (proceed) {
                     listener.executeSearch(searchEditText.getText().toString());

--- a/src/app/src/main/java/com/example/bookmark/fragments/SearchDialogFragment.java
+++ b/src/app/src/main/java/com/example/bookmark/fragments/SearchDialogFragment.java
@@ -1,0 +1,4 @@
+package com.example.bookmark.fragments;
+
+public class SearchDialogFragment {
+}

--- a/src/app/src/main/java/com/example/bookmark/fragments/SearchDialogFragment.java
+++ b/src/app/src/main/java/com/example/bookmark/fragments/SearchDialogFragment.java
@@ -63,7 +63,7 @@ public class SearchDialogFragment extends DialogFragment {
         dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                boolean proceed = Boolean.TRUE;
+                boolean proceed = true;
                 // There must be some text in the search bar to execute a search
                 if (TextUtils.isEmpty(searchEditText.getText())) {
                     searchEditText.setError("Please enter the keywords that " +

--- a/src/app/src/main/res/layout/activity_explore.xml
+++ b/src/app/src/main/res/layout/activity_explore.xml
@@ -4,6 +4,22 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:focusable="true"
     tools:context=".ExploreActivity">
+
+    <ListView
+        android:id="@+id/search_results_listview"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginStart="4dp"
+        android:layout_marginTop="4dp"
+        android:layout_marginEnd="4dp"
+        android:layout_marginBottom="4dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+    </ListView>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/src/app/src/main/res/layout/fragment_search_dialog.xml
+++ b/src/app/src/main/res/layout/fragment_search_dialog.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent" android:layout_height="match_parent">
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/book_preview_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <EditText
+        android:id="@+id/search_bar_editText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+        android:layout_marginEnd="10dp"
+        android:focusable="true"
+        android:hint="@string/search_hint"
+        android:inputType="text"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/src/app/src/main/res/layout/fragment_search_dialog.xml
+++ b/src/app/src/main/res/layout/fragment_search_dialog.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent" android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name">Bookmark</string>
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="search_hint">Search</string>
     <string name="search">search</string>
     <string name="main_menu">main_menu</string>
     <string name="edit">edit</string>


### PR DESCRIPTION
- implemented SearchDialogFragment
- implemented fragment_search_dialog.xml
- implemented ExploreActivity
- implemented activity_explore.xml
- clicking the search button from any page now will bring up the search fragment
    - upon the user clicking cancel the fragment will simply close
    - upon the user clicking confirm the fragment will verify that the search bar is not empty (if it is empty it will prompt the user to enter a keyword and will remain open), and then will take the user to the Explore page where the search results will be displayed
- all pages that have a search icon in the menu bar on top now support the functionality mentioned above (this can be changed on a per-page basis as each one of these pages (ExploreActivity, MyBooksActivity, BorrowedActivity, and PendingRequestsActivity) implements the executeSearch from the OnFragmentInteractionListener interface that is part of the SearchDialogFragment class) 

Relevant issue(s):
- #11 
- #17 