### PR TITLE
Fix subtle bugs in InMemoryStorageService

### DIFF
--- a/src/app/src/androidTest/java/com/example/bookmark/FirebaseStorageServiceTest.java
+++ b/src/app/src/androidTest/java/com/example/bookmark/FirebaseStorageServiceTest.java
@@ -5,6 +5,7 @@ import com.example.bookmark.models.Request;
 import com.example.bookmark.models.User;
 import com.example.bookmark.server.FirebaseStorageService;
 import com.example.bookmark.server.FirestoreIndexable;
+import com.example.bookmark.server.InMemoryStorageService;
 import com.example.bookmark.server.StorageService;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
@@ -65,7 +66,8 @@ public class FirebaseStorageServiceTest {
         }
     }
 
-    private static final StorageService storageService = new MockFirebaseStorageService();
+    private static final boolean INTERACT_WITH_FIREBASE = false;
+    private static final StorageService storageService = INTERACT_WITH_FIREBASE ? new MockFirebaseStorageService() : new InMemoryStorageService();
 
     /**
      * Creates and populates the database before the tests are run.
@@ -74,27 +76,27 @@ public class FirebaseStorageServiceTest {
     public static void createDatabase() {
         Semaphore semaphore = new Semaphore(0);
 
-        User owner = MockModels.mockOwner();
+        User owner = MockModels.getMockOwner();
         storageService.storeUser(owner, aVoid -> semaphore.release(), e -> fail("An error occurred while storing the owner."));
         acquire(semaphore);
 
-        User requester = MockModels.mockRequester();
+        User requester = MockModels.getMockRequester();
         storageService.storeUser(requester, aVoid -> semaphore.release(), e -> fail("An error occurred while storing the requester."));
         acquire(semaphore);
 
-        Book book1 = MockModels.mockBook1();
+        Book book1 = MockModels.getMockBook1();
         storageService.storeBook(book1, aVoid -> semaphore.release(), e -> fail("An error occurred while storing book 1."));
         acquire(semaphore);
 
-        Book book2 = MockModels.mockBook2();
+        Book book2 = MockModels.getMockBook2();
         storageService.storeBook(book2, aVoid -> semaphore.release(), e -> fail("An error occurred while storing book 2."));
         acquire(semaphore);
 
-        Request request1 = MockModels.mockRequest1();
+        Request request1 = MockModels.getMockRequest1();
         storageService.storeRequest(request1, aVoid -> semaphore.release(), e -> fail("An error occurred while storing request 1."));
         acquire(semaphore);
 
-        Request request2 = MockModels.mockRequest2();
+        Request request2 = MockModels.getMockRequest2();
         storageService.storeRequest(request2, aVoid -> semaphore.release(), e -> fail("An error occurred while storing request 2."));
         acquire(semaphore);
     }
@@ -105,7 +107,7 @@ public class FirebaseStorageServiceTest {
     @Test
     public void testRetrieveUser() {
         Semaphore semaphore = new Semaphore(0);
-        User user = MockModels.mockOwner();
+        User user = MockModels.getMockOwner();
         storageService.retrieveUserByUsername(user.getUsername(), user2 -> {
             assertEquals(user, user2);
             semaphore.release();
@@ -119,8 +121,8 @@ public class FirebaseStorageServiceTest {
     @Test
     public void testRetrieveBook() {
         Semaphore semaphore = new Semaphore(0);
-        User owner = MockModels.mockOwner();
-        Book book = MockModels.mockBook1();
+        User owner = MockModels.getMockOwner();
+        Book book = MockModels.getMockBook1();
         storageService.retrieveBook(owner, book.getIsbn(), book2 -> {
             assertEquals(book, book2);
             semaphore.release();
@@ -134,8 +136,8 @@ public class FirebaseStorageServiceTest {
     @Test
     public void testRetrieveMultipleBooks() {
         Semaphore semaphore = new Semaphore(0);
-        Book book1 = MockModels.mockBook1();
-        Book book2 = MockModels.mockBook2();
+        Book book1 = MockModels.getMockBook1();
+        Book book2 = MockModels.getMockBook2();
         storageService.retrieveBooks(books -> {
             assertTrue(books.contains(book1));
             assertTrue(books.contains(book2));
@@ -150,9 +152,9 @@ public class FirebaseStorageServiceTest {
     @Test
     public void testRetrieveMultipleBooksByOwner() {
         Semaphore semaphore = new Semaphore(0);
-        User owner = MockModels.mockOwner();
-        Book book1 = MockModels.mockBook1();
-        Book book2 = MockModels.mockBook2();
+        User owner = MockModels.getMockOwner();
+        Book book1 = MockModels.getMockBook1();
+        Book book2 = MockModels.getMockBook2();
         storageService.retrieveBooksByOwner(owner, books -> {
             assertTrue(books.contains(book1));
             assertTrue(books.contains(book2));
@@ -167,9 +169,9 @@ public class FirebaseStorageServiceTest {
     @Test
     public void testRetrieveMultipleBooksByRequester() {
         Semaphore semaphore = new Semaphore(0);
-        Book book1 = MockModels.mockBook1();
-        Book book2 = MockModels.mockBook2();
-        User requester = MockModels.mockRequester();
+        Book book1 = MockModels.getMockBook1();
+        Book book2 = MockModels.getMockBook2();
+        User requester = MockModels.getMockRequester();
         storageService.retrieveBooksByRequester(requester, books -> {
             assertTrue(books.contains(book1));
             assertTrue(books.contains(book2));
@@ -184,9 +186,9 @@ public class FirebaseStorageServiceTest {
     @Test
     public void testRetrieveRequest() {
         Semaphore semaphore = new Semaphore(0);
-        Book book = MockModels.mockBook1();
-        User requester = MockModels.mockRequester();
-        Request request = MockModels.mockRequest1();
+        Book book = MockModels.getMockBook1();
+        User requester = MockModels.getMockRequester();
+        Request request = MockModels.getMockRequest1();
         storageService.retrieveRequest(book, requester, request2 -> {
             assertEquals(request, request2);
             semaphore.release();
@@ -200,9 +202,9 @@ public class FirebaseStorageServiceTest {
     @Test
     public void testDeleteRequest() {
         Semaphore semaphore = new Semaphore(0);
-        Book book = MockModels.mockBook1();
-        User requester = MockModels.mockRequester();
-        Request request = MockModels.mockRequest1();
+        Book book = MockModels.getMockBook1();
+        User requester = MockModels.getMockRequester();
+        Request request = MockModels.getMockRequest1();
         storageService.deleteRequest(request, aVoid ->
                 storageService.retrieveRequest(book, requester, request2 ->
                         storageService.storeRequest(request, aVoid2 -> {
@@ -220,12 +222,10 @@ public class FirebaseStorageServiceTest {
     @Test
     public void testRetrieveMultipleRequestsByBook() {
         Semaphore semaphore = new Semaphore(0);
-        Book book = MockModels.mockBook1();
-        Request request1 = MockModels.mockRequest1();
-        Request request2 = MockModels.mockRequest2();
+        Book book = MockModels.getMockBook1();
+        Request request = MockModels.getMockRequest1();
         storageService.retrieveRequestsByBook(book, requests -> {
-            assertTrue(requests.contains(request1));
-            assertTrue(requests.contains(request2));
+            assertTrue(requests.contains(request));
             semaphore.release();
         }, e -> fail("An error occurred while retrieving the requests by book."));
         acquire(semaphore);
@@ -237,9 +237,9 @@ public class FirebaseStorageServiceTest {
     @Test
     public void testRetrieveMultipleRequestsByRequester() {
         Semaphore semaphore = new Semaphore(0);
-        User requester = MockModels.mockRequester();
-        Request request1 = MockModels.mockRequest1();
-        Request request2 = MockModels.mockRequest2();
+        User requester = MockModels.getMockRequester();
+        Request request1 = MockModels.getMockRequest1();
+        Request request2 = MockModels.getMockRequest2();
         storageService.retrieveRequestsByRequester(requester, requests -> {
             assertTrue(requests.contains(request1));
             assertTrue(requests.contains(request2));

--- a/src/app/src/androidTest/java/com/example/bookmark/mocks/MockModels.java
+++ b/src/app/src/androidTest/java/com/example/bookmark/mocks/MockModels.java
@@ -11,27 +11,35 @@ import com.example.bookmark.models.User;
  * @author Kyle Hennig.
  */
 public class MockModels {
-    public static User mockOwner() {
-        return new User("john.smith42", "John", "Smith", "jsmith@ualberta.ca", "7801234567");
+    private static final User mockOwner = new User("john.smith42", "John", "Smith", "jsmith@ualberta.ca", "7801234567");
+    private static final User mockRequester = new User("mary.jane9", "Mary", "Jane", "mjane@ualberta.ca", "7809999999");
+    private static final Book mockBook1 = new Book(mockOwner, "Code Complete 2", "Steve McConnell", "0-7356-1976-0");
+    private static final Book mockBook2 = new Book(mockOwner, "Programming Pearls", "Jon Bentley", "978-0-201-65788-3");
+    private static final Geolocation mockLocation = new Geolocation(53.5461, -113.4938);
+    private static final Request request1 = new Request(mockBook1, mockRequester, mockLocation);
+    private static final Request request2 = new Request(mockBook2, mockRequester, mockLocation);
+
+    public static User getMockOwner() {
+        return mockOwner;
     }
 
-    public static User mockRequester() {
-        return new User("mary.jane9", "Mary", "Jane", "mjane@ualberta.ca", "7809999999");
+    public static User getMockRequester() {
+        return mockRequester;
     }
 
-    public static Book mockBook1() {
-        return new Book(mockOwner(), "Code Complete 2", "Steve McConnell", "0-7356-1976-0");
+    public static Book getMockBook1() {
+        return mockBook1;
     }
 
-    public static Book mockBook2() {
-        return new Book(mockOwner(), "Programming Pearls", "Jon Bentley", "978-0-201-65788-3");
+    public static Book getMockBook2() {
+        return mockBook2;
     }
 
-    public static Request mockRequest1() {
-        return new Request(mockBook1(), mockRequester(), new Geolocation(53.5461, -113.4938));
+    public static Request getMockRequest1() {
+        return request1;
     }
 
-    public static Request mockRequest2() {
-        return new Request(mockBook1(), mockRequester(), new Geolocation(53.5461, -113.4938));
+    public static Request getMockRequest2() {
+        return request2;
     }
 }

--- a/src/app/src/androidTest/java/com/example/bookmark/mocks/MockStorageService.java
+++ b/src/app/src/androidTest/java/com/example/bookmark/mocks/MockStorageService.java
@@ -15,16 +15,16 @@ import java.util.List;
  * @author Kyle Hennig.
  */
 public class MockStorageService {
-    public static StorageService mockStorageService() {
+    public static StorageService getMockStorageService() {
         List<User> users = new ArrayList<>();
-        users.add(MockModels.mockOwner());
-        users.add(MockModels.mockRequester());
+        users.add(MockModels.getMockOwner());
+        users.add(MockModels.getMockRequester());
         List<Book> books = new ArrayList<>();
-        books.add(MockModels.mockBook1());
-        books.add(MockModels.mockBook2());
+        books.add(MockModels.getMockBook1());
+        books.add(MockModels.getMockBook2());
         List<Request> requests = new ArrayList<>();
-        requests.add(MockModels.mockRequest1());
-        requests.add(MockModels.mockRequest2());
+        requests.add(MockModels.getMockRequest1());
+        requests.add(MockModels.getMockRequest2());
         return new InMemoryStorageService(users, books, requests);
     }
 }

--- a/src/app/src/main/java/com/example/bookmark/models/Request.java
+++ b/src/app/src/main/java/com/example/bookmark/models/Request.java
@@ -137,9 +137,9 @@ public class Request implements FirestoreIndexable, Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Request request = (Request) o;
-        return Objects.equals(bookId, request.bookId) &&
+        return createdDate == request.createdDate &&
+            Objects.equals(bookId, request.bookId) &&
             Objects.equals(requesterId, request.requesterId) &&
-            //Objects.equals(createdDate, request.createdDate) &&
             Objects.equals(location, request.location) &&
             status == request.status;
     }

--- a/src/app/src/main/java/com/example/bookmark/server/InMemoryStorageService.java
+++ b/src/app/src/main/java/com/example/bookmark/server/InMemoryStorageService.java
@@ -114,7 +114,7 @@ public class InMemoryStorageService implements StorageService {
     @Override
     public void retrieveRequest(Book book, User requester, OnSuccessListener<Request> onSuccessListener, OnFailureListener onFailureListener) {
         for (Request request : requests) {
-            if (request.getBookId().equals(book.getId()) && request.getRequesterId().equals(request.getId())) {
+            if (request.getBookId().equals(book.getId()) && request.getRequesterId().equals(requester.getId())) {
                 onSuccessListener.onSuccess(request);
                 return;
             }


### PR DESCRIPTION
- Fixes the wrong ids being compared in retrieveRequest.
- Fixes Request objects being initialized multiple times. This caused their createdDate to differ and equality comparisons to fail.
- Allows changing a boolean flag INTERACT_WITH_FIREBASE in FirebaseStorageServiceTest to determine whether the tests should actually make requests to Firebase's API. Defaults to false.