### PR TITLE
Update image select dialog fragment to use outlined buttons

### DIFF
--- a/src/app/src/main/res/layout/fragment_image_select_dialog.xml
+++ b/src/app/src/main/res/layout/fragment_image_select_dialog.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- TODO: Prettify, eliminate hardcoding, investigate button styling -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -11,12 +10,14 @@
 
     <Button
         android:id="@+id/button_gallery_photo"
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/choose_from_gallery" />
 
     <Button
         android:id="@+id/button_take_photo"
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/take_photo" />


### PR DESCRIPTION
Quick style update. The button were previously using the default style pre-material.io components. This update makes this layout consistent with the design on Figma.