### PR TITLE
Assign ids independent of user input

### DIFF
--- a/src/app/src/androidTest/java/com/example/bookmark/FirebaseStorageServiceTest.java
+++ b/src/app/src/androidTest/java/com/example/bookmark/FirebaseStorageServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.bookmark;
 
+import com.example.bookmark.mocks.MockModels;
 import com.example.bookmark.models.Book;
 import com.example.bookmark.models.Request;
 import com.example.bookmark.models.User;
@@ -15,11 +16,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.function.Function;
-
-import com.example.bookmark.mocks.MockModels;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -42,18 +40,18 @@ public class FirebaseStorageServiceTest {
         }
 
         @Override
-        protected <T> void retrieveEntity(String collection, String id, Function<Map<String, Object>, T> fromFirestoreDocument, OnSuccessListener<T> onSuccessListener, OnFailureListener onFailureListener) {
-            super.retrieveEntity(mock(collection), id, fromFirestoreDocument, onSuccessListener, onFailureListener);
+        protected <T> void retrieveEntity(String collection, String id, FirestoreDeserializer<T> deserializer, OnSuccessListener<T> onSuccessListener, OnFailureListener onFailureListener) {
+            super.retrieveEntity(mock(collection), id, deserializer, onSuccessListener, onFailureListener);
         }
 
         @Override
-        protected <T> void retrieveEntities(String collection, Function<Map<String, Object>, T> fromFirestoreDocument, OnSuccessListener<List<T>> onSuccessListener, OnFailureListener onFailureListener) {
-            super.retrieveEntities(mock(collection), fromFirestoreDocument, onSuccessListener, onFailureListener);
+        protected <T> void retrieveEntities(String collection, FirestoreDeserializer<T> deserializer, OnSuccessListener<List<T>> onSuccessListener, OnFailureListener onFailureListener) {
+            super.retrieveEntities(mock(collection), deserializer, onSuccessListener, onFailureListener);
         }
 
         @Override
-        protected <T> void retrieveEntitiesMatching(String collection, Function<Query, Query> conditions, Function<Map<String, Object>, T> fromFirestoreDocument, OnSuccessListener<List<T>> onSuccessListener, OnFailureListener onFailureListener) {
-            super.retrieveEntitiesMatching(mock(collection), conditions, fromFirestoreDocument, onSuccessListener, onFailureListener);
+        protected <T> void retrieveEntitiesMatching(String collection, Function<Query, Query> conditions, FirestoreDeserializer<T> deserializer, OnSuccessListener<List<T>> onSuccessListener, OnFailureListener onFailureListener) {
+            super.retrieveEntitiesMatching(mock(collection), conditions, deserializer, onSuccessListener, onFailureListener);
         }
 
         @Override
@@ -121,9 +119,8 @@ public class FirebaseStorageServiceTest {
     @Test
     public void testRetrieveBook() {
         Semaphore semaphore = new Semaphore(0);
-        User owner = MockModels.getMockOwner();
         Book book = MockModels.getMockBook1();
-        storageService.retrieveBook(owner, book.getIsbn(), book2 -> {
+        storageService.retrieveBook(book.getId(), book2 -> {
             assertEquals(book, book2);
             semaphore.release();
         }, e -> fail("An error occurred while retrieving the book."));
@@ -186,10 +183,9 @@ public class FirebaseStorageServiceTest {
     @Test
     public void testDeleteBook() {
         Semaphore semaphore = new Semaphore(0);
-        User owner = MockModels.getMockOwner();
         Book book = MockModels.getMockBook1();
         storageService.deleteBook(book, aVoid ->
-                storageService.retrieveBook(owner, book.getIsbn(), book2 ->
+                storageService.retrieveBook(book.getId(), book2 ->
                         storageService.storeBook(book, aVoid2 -> {
                             assertNull(book2);
                             semaphore.release();
@@ -205,10 +201,8 @@ public class FirebaseStorageServiceTest {
     @Test
     public void testRetrieveRequest() {
         Semaphore semaphore = new Semaphore(0);
-        Book book = MockModels.getMockBook1();
-        User requester = MockModels.getMockRequester();
         Request request = MockModels.getMockRequest1();
-        storageService.retrieveRequest(book, requester, request2 -> {
+        storageService.retrieveRequest(request.getId(), request2 -> {
             assertEquals(request, request2);
             semaphore.release();
         }, e -> fail("An error occurred while retrieving the request."));
@@ -221,11 +215,9 @@ public class FirebaseStorageServiceTest {
     @Test
     public void testDeleteRequest() {
         Semaphore semaphore = new Semaphore(0);
-        Book book = MockModels.getMockBook1();
-        User requester = MockModels.getMockRequester();
         Request request = MockModels.getMockRequest1();
         storageService.deleteRequest(request, aVoid ->
-                storageService.retrieveRequest(book, requester, request2 ->
+                storageService.retrieveRequest(request.getId(), request2 ->
                         storageService.storeRequest(request, aVoid2 -> {
                             assertNull(request2);
                             semaphore.release();

--- a/src/app/src/main/java/com/example/bookmark/adapters/RequestList.java
+++ b/src/app/src/main/java/com/example/bookmark/adapters/RequestList.java
@@ -69,7 +69,7 @@ public class RequestList extends ArrayAdapter<Request> {
         TextView borrowerName = view.findViewById(R.id.borrower_text);
         TextView requestDate = view.findViewById(R.id.request_date_text);
 
-        borrowerName.setText(request.getRequesterId());
+        borrowerName.setText(request.getRequesterId().toString());
 
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
 

--- a/src/app/src/main/java/com/example/bookmark/models/Book.java
+++ b/src/app/src/main/java/com/example/bookmark/models/Book.java
@@ -17,6 +17,9 @@ public class Book implements FirestoreIndexable, Serializable {
         AVAILABLE, REQUESTED, ACCEPTED, BORROWED
     }
 
+    // Null if not stored to Firebase.
+    private final String id;
+
     private final String ownerId;
     private String title;
     private String author;
@@ -35,10 +38,11 @@ public class Book implements FirestoreIndexable, Serializable {
      * @param isbn   The ISBN.
      */
     public Book(User owner, String title, String author, String isbn) {
-        this(owner.getId(), title, author, isbn);
+        this(null, owner.getId(), title, author, isbn);
     }
 
-    private Book(String ownerId, String title, String author, String isbn) {
+    private Book(String id, String ownerId, String title, String author, String isbn) {
+        this.id = id;
         this.ownerId = ownerId;
         this.title = title;
         this.author = author;
@@ -164,7 +168,7 @@ public class Book implements FirestoreIndexable, Serializable {
 
     @Override
     public String getId() {
-        return String.format("%s:%s", ownerId, isbn);
+        return id;
     }
 
     @Override
@@ -180,11 +184,17 @@ public class Book implements FirestoreIndexable, Serializable {
         return map;
     }
 
-    public static Book fromFirestoreDocument(Map<String, Object> map) {
+    public static Book fromFirestoreDocument(String id, Map<String, Object> map) {
         if (map == null) {
             return null;
         }
-        Book book = new Book((String) map.get("ownerId"), (String) map.get("title"), (String) map.get("author"), (String) map.get("isbn"));
+        Book book = new Book(
+            id,
+            (String) map.get("ownerId"),
+            (String) map.get("title"),
+            (String) map.get("author"),
+            (String) map.get("isbn")
+        );
         book.photograph = Photograph.fromFirestoreDocument((Map<String, Object>) map.get("photograph"));
         book.description = (String) map.get("description");
         book.status = Status.valueOf((String) map.get("status"));

--- a/src/app/src/main/java/com/example/bookmark/models/Book.java
+++ b/src/app/src/main/java/com/example/bookmark/models/Book.java
@@ -17,10 +17,9 @@ public class Book implements FirestoreIndexable, Serializable {
         AVAILABLE, REQUESTED, ACCEPTED, BORROWED
     }
 
-    // Null if not stored to Firebase.
-    private final String id;
+    private final EntityId id;
 
-    private final String ownerId;
+    private final EntityId ownerId;
     private String title;
     private String author;
     private String isbn;
@@ -38,10 +37,10 @@ public class Book implements FirestoreIndexable, Serializable {
      * @param isbn   The ISBN.
      */
     public Book(User owner, String title, String author, String isbn) {
-        this(null, owner.getId(), title, author, isbn);
+        this(new EntityId(), owner.getId(), title, author, isbn);
     }
 
-    private Book(String id, String ownerId, String title, String author, String isbn) {
+    private Book(EntityId id, EntityId ownerId, String title, String author, String isbn) {
         this.id = id;
         this.ownerId = ownerId;
         this.title = title;
@@ -54,7 +53,7 @@ public class Book implements FirestoreIndexable, Serializable {
      *
      * @return The id of the owner.
      */
-    public String getOwnerId() {
+    public EntityId getOwnerId() {
         return ownerId;
     }
 
@@ -167,14 +166,14 @@ public class Book implements FirestoreIndexable, Serializable {
     }
 
     @Override
-    public String getId() {
+    public EntityId getId() {
         return id;
     }
 
     @Override
     public Map<String, Object> toFirestoreDocument() {
         Map<String, Object> map = new HashMap<>();
-        map.put("ownerId", ownerId);
+        map.put("ownerId", ownerId.toString());
         map.put("title", title);
         map.put("author", author);
         map.put("isbn", isbn);
@@ -189,8 +188,8 @@ public class Book implements FirestoreIndexable, Serializable {
             return null;
         }
         Book book = new Book(
-            id,
-            (String) map.get("ownerId"),
+            new EntityId(id),
+            new EntityId((String) map.get("ownerId")),
             (String) map.get("title"),
             (String) map.get("author"),
             (String) map.get("isbn")

--- a/src/app/src/main/java/com/example/bookmark/models/Book.java
+++ b/src/app/src/main/java/com/example/bookmark/models/Book.java
@@ -73,12 +73,30 @@ public class Book implements FirestoreIndexable, Serializable {
     }
 
     /**
+     * Set the author.
+     *
+     * @param author The author.
+     */
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    /**
      * Gets the ISBN.
      *
      * @return The ISBN.
      */
     public String getIsbn() {
         return isbn;
+    }
+
+    /**
+     * Sets the ISBN.
+     *
+     * @param isbn The ISBN.
+     */
+    public void setIsbn(String isbn) {
+        this.isbn = isbn;
     }
 
     /**
@@ -142,24 +160,6 @@ public class Book implements FirestoreIndexable, Serializable {
      */
     public void setTitle(String title) {
         this.title = title;
-    }
-
-    /**
-     * Set the author
-     *
-     * @param author The author.
-     */
-    public void setAuthor(String author) {
-        this.author = author;
-    }
-
-    /**
-     * Sets the isbn
-     *
-     * @param isbn The isbn.
-     */
-    public void setIsbn(String isbn) {
-        this.isbn = isbn;
     }
 
     @Override

--- a/src/app/src/main/java/com/example/bookmark/models/Book.java
+++ b/src/app/src/main/java/com/example/bookmark/models/Book.java
@@ -76,7 +76,7 @@ public class Book implements FirestoreIndexable, Serializable {
     }
 
     /**
-     * Set the author.
+     * Sets the author.
      *
      * @param author The author.
      */

--- a/src/app/src/main/java/com/example/bookmark/models/EntityId.java
+++ b/src/app/src/main/java/com/example/bookmark/models/EntityId.java
@@ -1,0 +1,37 @@
+package com.example.bookmark.models;
+
+import androidx.annotation.NonNull;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public class EntityId {
+    private final String id;
+
+    public EntityId() {
+        this.id = UUID.randomUUID().toString();
+    }
+
+    public EntityId(String id) {
+        this.id = id;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        EntityId entityId = (EntityId) o;
+        return Objects.equals(id, entityId.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/app/src/main/java/com/example/bookmark/models/Request.java
+++ b/src/app/src/main/java/com/example/bookmark/models/Request.java
@@ -117,8 +117,8 @@ public class Request implements FirestoreIndexable, Serializable {
     @Override
     public Map<String, Object> toFirestoreDocument() {
         Map<String, Object> map = new HashMap<>();
-        map.put("bookId", bookId);
-        map.put("requesterId", requesterId);
+        map.put("bookId", bookId.toString());
+        map.put("requesterId", requesterId.toString());
         map.put("createdDate", createdDate);
         map.put("location", location != null ? location.toFirestoreDocument() : null);
         map.put("status", status);

--- a/src/app/src/main/java/com/example/bookmark/models/Request.java
+++ b/src/app/src/main/java/com/example/bookmark/models/Request.java
@@ -18,11 +18,10 @@ public class Request implements FirestoreIndexable, Serializable {
         REQUESTED, ACCEPTED, BORROWED
     }
 
-    // Null if not stored to Firebase.
-    private final String id;
+    private final EntityId id;
 
-    private final String bookId;
-    private final String requesterId;
+    private final EntityId bookId;
+    private final EntityId requesterId;
     private final long createdDate; // Stored as a long since Date::equals is flawed.
 
     private Geolocation location;
@@ -36,10 +35,10 @@ public class Request implements FirestoreIndexable, Serializable {
      * @param location  The pickup location.
      */
     public Request(Book book, User requester, Geolocation location) {
-        this(null, book.getId(), requester.getId(), new Date().getTime(), location);
+        this(new EntityId(), book.getId(), requester.getId(), new Date().getTime(), location);
     }
 
-    private Request(String id, String bookId, String requesterId, long createdDate, Geolocation location) {
+    private Request(EntityId id, EntityId bookId, EntityId requesterId, long createdDate, Geolocation location) {
         this.id = id;
         this.bookId = bookId;
         this.requesterId = requesterId;
@@ -52,7 +51,7 @@ public class Request implements FirestoreIndexable, Serializable {
      *
      * @return The id of the requested book.
      */
-    public String getBookId() {
+    public EntityId getBookId() {
         return bookId;
     }
 
@@ -61,7 +60,7 @@ public class Request implements FirestoreIndexable, Serializable {
      *
      * @return The id of the requester.
      */
-    public String getRequesterId() {
+    public EntityId getRequesterId() {
         return requesterId;
     }
 
@@ -111,7 +110,7 @@ public class Request implements FirestoreIndexable, Serializable {
     }
 
     @Override
-    public String getId() {
+    public EntityId getId() {
         return id;
     }
 
@@ -132,9 +131,9 @@ public class Request implements FirestoreIndexable, Serializable {
         }
         Geolocation location = Geolocation.fromFirestoreDocument((Map<String, Object>) map.get("location"));
         Request request = new Request(
-            id,
-            (String) map.get("bookId"),
-            (String) map.get("requesterId"),
+            new EntityId(id),
+            new EntityId((String) map.get("bookId")),
+            new EntityId((String) map.get("requesterId")),
             (long) map.get("createdDate"),
             location
         );

--- a/src/app/src/main/java/com/example/bookmark/models/User.java
+++ b/src/app/src/main/java/com/example/bookmark/models/User.java
@@ -31,7 +31,7 @@ public class User implements FirestoreIndexable, Serializable {
      * @param phoneNumber  The user's phone number.
      */
     public User(String username, String firstName, String lastName, String emailAddress, String phoneNumber) {
-        this(new EntityId(), username, firstName, lastName, emailAddress, phoneNumber);
+        this(new EntityId(username), username, firstName, lastName, emailAddress, phoneNumber);
     }
 
     private User(EntityId id, String username, String firstName, String lastName, String emailAddress, String phoneNumber) {

--- a/src/app/src/main/java/com/example/bookmark/models/User.java
+++ b/src/app/src/main/java/com/example/bookmark/models/User.java
@@ -13,6 +13,9 @@ import java.util.Objects;
  * @author Kyle Hennig.
  */
 public class User implements FirestoreIndexable, Serializable {
+    // Null if not stored to Firebase.
+    private final String id;
+
     private final String username;
     private String firstName;
     private String lastName;
@@ -29,6 +32,11 @@ public class User implements FirestoreIndexable, Serializable {
      * @param phoneNumber  The user's phone number.
      */
     public User(String username, String firstName, String lastName, String emailAddress, String phoneNumber) {
+        this(null, username, firstName, lastName, emailAddress, phoneNumber);
+    }
+
+    private User(String id, String username, String firstName, String lastName, String emailAddress, String phoneNumber) {
+        this.id = id;
         this.username = username;
         this.firstName = firstName;
         this.lastName = lastName;
@@ -119,7 +127,7 @@ public class User implements FirestoreIndexable, Serializable {
 
     @Override
     public String getId() {
-        return username;
+        return id;
     }
 
     @Override
@@ -133,11 +141,12 @@ public class User implements FirestoreIndexable, Serializable {
         return map;
     }
 
-    public static User fromFirestoreDocument(Map<String, Object> map) {
+    public static User fromFirestoreDocument(String id, Map<String, Object> map) {
         if (map == null) {
             return null;
         }
         return new User(
+            id,
             (String) map.get("username"),
             (String) map.get("firstName"),
             (String) map.get("lastName"),

--- a/src/app/src/main/java/com/example/bookmark/models/User.java
+++ b/src/app/src/main/java/com/example/bookmark/models/User.java
@@ -13,8 +13,7 @@ import java.util.Objects;
  * @author Kyle Hennig.
  */
 public class User implements FirestoreIndexable, Serializable {
-    // Null if not stored to Firebase.
-    private final String id;
+    private final EntityId id;
 
     private final String username;
     private String firstName;
@@ -32,10 +31,10 @@ public class User implements FirestoreIndexable, Serializable {
      * @param phoneNumber  The user's phone number.
      */
     public User(String username, String firstName, String lastName, String emailAddress, String phoneNumber) {
-        this(null, username, firstName, lastName, emailAddress, phoneNumber);
+        this(new EntityId(), username, firstName, lastName, emailAddress, phoneNumber);
     }
 
-    private User(String id, String username, String firstName, String lastName, String emailAddress, String phoneNumber) {
+    private User(EntityId id, String username, String firstName, String lastName, String emailAddress, String phoneNumber) {
         this.id = id;
         this.username = username;
         this.firstName = firstName;
@@ -126,7 +125,7 @@ public class User implements FirestoreIndexable, Serializable {
     }
 
     @Override
-    public String getId() {
+    public EntityId getId() {
         return id;
     }
 
@@ -146,7 +145,7 @@ public class User implements FirestoreIndexable, Serializable {
             return null;
         }
         return new User(
-            id,
+            new EntityId(id),
             (String) map.get("username"),
             (String) map.get("firstName"),
             (String) map.get("lastName"),

--- a/src/app/src/main/java/com/example/bookmark/server/FirebaseStorageService.java
+++ b/src/app/src/main/java/com/example/bookmark/server/FirebaseStorageService.java
@@ -52,12 +52,6 @@ public class FirebaseStorageService implements StorageService {
     }
 
     @Override
-    public void retrieveBook(User owner, String isbn, OnSuccessListener<Book> onSuccessListener, OnFailureListener onFailureListener) {
-        String id = String.format("%s:%s", owner.getId(), isbn);
-        retrieveEntity(Collection.BOOKS, id, Book::fromFirestoreDocument, onSuccessListener, onFailureListener);
-    }
-
-    @Override
     public void retrieveBooks(OnSuccessListener<List<Book>> onSuccessListener, OnFailureListener onFailureListener) {
         retrieveEntities(Collection.BOOKS, Book::fromFirestoreDocument, onSuccessListener, onFailureListener);
     }
@@ -94,12 +88,6 @@ public class FirebaseStorageService implements StorageService {
     @Override
     public void storeRequest(Request request, OnSuccessListener<Void> onSuccessListener, OnFailureListener onFailureListener) {
         storeEntity(Collection.REQUESTS, request, onSuccessListener, onFailureListener);
-    }
-
-    @Override
-    public void retrieveRequest(Book book, User requester, OnSuccessListener<Request> onSuccessListener, OnFailureListener onFailureListener) {
-        String id = String.format("%s:%s", book.getId(), requester.getId());
-        retrieveEntity(Collection.REQUESTS, id, Request::fromFirestoreDocument, onSuccessListener, onFailureListener);
     }
 
     @Override
@@ -167,7 +155,7 @@ public class FirebaseStorageService implements StorageService {
             });
     }
 
-    protected <T> void retrieveEntitiesMatching(String collection, Function<Query, Query> conditions,FirestoreDeserializer<T> deserializer, OnSuccessListener<List<T>> onSuccessListener, OnFailureListener onFailureListener) {
+    protected <T> void retrieveEntitiesMatching(String collection, Function<Query, Query> conditions, FirestoreDeserializer<T> deserializer, OnSuccessListener<List<T>> onSuccessListener, OnFailureListener onFailureListener) {
         conditions.apply(db.collection(collection))
             .get()
             .addOnSuccessListener(queryDocumentSnapshots -> {

--- a/src/app/src/main/java/com/example/bookmark/server/FirebaseStorageService.java
+++ b/src/app/src/main/java/com/example/bookmark/server/FirebaseStorageService.java
@@ -64,7 +64,7 @@ public class FirebaseStorageService implements StorageService {
 
     @Override
     public void retrieveBooksByOwner(User owner, OnSuccessListener<List<Book>> onSuccessListener, OnFailureListener onFailureListener) {
-        retrieveEntitiesMatching(Collection.BOOKS, query -> query.whereEqualTo("ownerId", owner.getId()), Book::fromFirestoreDocument, onSuccessListener, onFailureListener);
+        retrieveEntitiesMatching(Collection.BOOKS, query -> query.whereEqualTo("ownerId", owner.getId().toString()), Book::fromFirestoreDocument, onSuccessListener, onFailureListener);
     }
 
     @Override
@@ -103,12 +103,12 @@ public class FirebaseStorageService implements StorageService {
 
     @Override
     public void retrieveRequestsByBook(Book book, OnSuccessListener<List<Request>> onSuccessListener, OnFailureListener onFailureListener) {
-        retrieveEntitiesMatching(Collection.REQUESTS, query -> query.whereEqualTo("bookId", book.getId()), Request::fromFirestoreDocument, onSuccessListener, onFailureListener);
+        retrieveEntitiesMatching(Collection.REQUESTS, query -> query.whereEqualTo("bookId", book.getId().toString()), Request::fromFirestoreDocument, onSuccessListener, onFailureListener);
     }
 
     @Override
     public void retrieveRequestsByRequester(User requester, OnSuccessListener<List<Request>> onSuccessListener, OnFailureListener onFailureListener) {
-        retrieveEntitiesMatching(Collection.REQUESTS, query -> query.whereEqualTo("requesterId", requester.getId()), Request::fromFirestoreDocument, onSuccessListener, onFailureListener);
+        retrieveEntitiesMatching(Collection.REQUESTS, query -> query.whereEqualTo("requesterId", requester.getId().toString()), Request::fromFirestoreDocument, onSuccessListener, onFailureListener);
     }
 
     @Override

--- a/src/app/src/main/java/com/example/bookmark/server/FirebaseStorageService.java
+++ b/src/app/src/main/java/com/example/bookmark/server/FirebaseStorageService.java
@@ -3,6 +3,7 @@ package com.example.bookmark.server;
 import android.util.Log;
 
 import com.example.bookmark.models.Book;
+import com.example.bookmark.models.EntityId;
 import com.example.bookmark.models.Request;
 import com.example.bookmark.models.User;
 import com.google.android.gms.tasks.OnFailureListener;
@@ -52,8 +53,8 @@ public class FirebaseStorageService implements StorageService {
     }
 
     @Override
-    public void retrieveBook(String id, OnSuccessListener<Book> onSuccessListener, OnFailureListener onFailureListener) {
-        retrieveEntity(Collection.BOOKS, id, Book::fromFirestoreDocument, onSuccessListener, onFailureListener);
+    public void retrieveBook(EntityId id, OnSuccessListener<Book> onSuccessListener, OnFailureListener onFailureListener) {
+        retrieveEntity(Collection.BOOKS, id.toString(), Book::fromFirestoreDocument, onSuccessListener, onFailureListener);
     }
 
     @Override
@@ -69,7 +70,7 @@ public class FirebaseStorageService implements StorageService {
     @Override
     public void retrieveBooksByRequester(User requester, OnSuccessListener<List<Book>> onSuccessListener, OnFailureListener onFailureListener) {
         retrieveRequestsByRequester(requester, requests -> {
-            List<String> bookIds = new ArrayList<>();
+            List<EntityId> bookIds = new ArrayList<>();
             for (Request request : requests) {
                 bookIds.add(request.getBookId());
             }
@@ -87,7 +88,7 @@ public class FirebaseStorageService implements StorageService {
 
     @Override
     public void deleteBook(Book book, OnSuccessListener<Void> onSuccessListener, OnFailureListener onFailureListener) {
-        deleteEntity(Collection.BOOKS, book.getId(), onSuccessListener, onFailureListener);
+        deleteEntity(Collection.BOOKS, book.getId().toString(), onSuccessListener, onFailureListener);
     }
 
     @Override
@@ -96,8 +97,8 @@ public class FirebaseStorageService implements StorageService {
     }
 
     @Override
-    public void retrieveRequest(String id, OnSuccessListener<Request> onSuccessListener, OnFailureListener onFailureListener) {
-        retrieveEntity(Collection.REQUESTS, id, Request::fromFirestoreDocument, onSuccessListener, onFailureListener);
+    public void retrieveRequest(EntityId id, OnSuccessListener<Request> onSuccessListener, OnFailureListener onFailureListener) {
+        retrieveEntity(Collection.REQUESTS, id.toString(), Request::fromFirestoreDocument, onSuccessListener, onFailureListener);
     }
 
     @Override
@@ -112,12 +113,12 @@ public class FirebaseStorageService implements StorageService {
 
     @Override
     public void deleteRequest(Request request, OnSuccessListener<Void> onSuccessListener, OnFailureListener onFailureListener) {
-        deleteEntity(Collection.REQUESTS, request.getId(), onSuccessListener, onFailureListener);
+        deleteEntity(Collection.REQUESTS, request.getId().toString(), onSuccessListener, onFailureListener);
     }
 
     protected void storeEntity(String collection, FirestoreIndexable entity, OnSuccessListener<Void> onSuccessListener, OnFailureListener onFailureListener) {
         db.collection(collection)
-            .document(entity.getId())
+            .document(entity.getId().toString())
             .set(entity.toFirestoreDocument())
             .addOnSuccessListener(aVoid -> {
                 Log.d(TAG, String.format("Stored %s with id %s to collection %s.", entity.getClass().getName().toLowerCase(), entity.getId(), collection));

--- a/src/app/src/main/java/com/example/bookmark/server/FirebaseStorageService.java
+++ b/src/app/src/main/java/com/example/bookmark/server/FirebaseStorageService.java
@@ -52,6 +52,11 @@ public class FirebaseStorageService implements StorageService {
     }
 
     @Override
+    public void retrieveBook(String id, OnSuccessListener<Book> onSuccessListener, OnFailureListener onFailureListener) {
+        retrieveEntity(Collection.BOOKS, id, Book::fromFirestoreDocument, onSuccessListener, onFailureListener);
+    }
+
+    @Override
     public void retrieveBooks(OnSuccessListener<List<Book>> onSuccessListener, OnFailureListener onFailureListener) {
         retrieveEntities(Collection.BOOKS, Book::fromFirestoreDocument, onSuccessListener, onFailureListener);
     }
@@ -88,6 +93,11 @@ public class FirebaseStorageService implements StorageService {
     @Override
     public void storeRequest(Request request, OnSuccessListener<Void> onSuccessListener, OnFailureListener onFailureListener) {
         storeEntity(Collection.REQUESTS, request, onSuccessListener, onFailureListener);
+    }
+
+    @Override
+    public void retrieveRequest(String id, OnSuccessListener<Request> onSuccessListener, OnFailureListener onFailureListener) {
+        retrieveEntity(Collection.REQUESTS, id, Request::fromFirestoreDocument, onSuccessListener, onFailureListener);
     }
 
     @Override

--- a/src/app/src/main/java/com/example/bookmark/server/FirestoreIndexable.java
+++ b/src/app/src/main/java/com/example/bookmark/server/FirestoreIndexable.java
@@ -1,5 +1,7 @@
 package com.example.bookmark.server;
 
+import com.example.bookmark.models.EntityId;
+
 /**
  * Interface for an object that can be assigned a unique id by Firebase for storage in a collection.
  *
@@ -11,5 +13,5 @@ public interface FirestoreIndexable extends FirestoreSerializable {
      *
      * @return The id.
      */
-    String getId();
+    EntityId getId();
 }

--- a/src/app/src/main/java/com/example/bookmark/server/InMemoryStorageService.java
+++ b/src/app/src/main/java/com/example/bookmark/server/InMemoryStorageService.java
@@ -1,6 +1,7 @@
 package com.example.bookmark.server;
 
 import com.example.bookmark.models.Book;
+import com.example.bookmark.models.EntityId;
 import com.example.bookmark.models.Request;
 import com.example.bookmark.models.User;
 import com.google.android.gms.tasks.OnFailureListener;
@@ -19,9 +20,9 @@ import java.util.UUID;
  * @author Kyle Hennig.
  */
 public class InMemoryStorageService implements StorageService {
-    private final Map<String, User> users = new HashMap<>();
-    private final Map<String, Book> books = new HashMap<>();
-    private final Map<String, Request> requests = new HashMap<>();
+    private final Map<EntityId, User> users = new HashMap<>();
+    private final Map<EntityId, Book> books = new HashMap<>();
+    private final Map<EntityId, Request> requests = new HashMap<>();
 
     /**
      * Creates an InMemoryStorageService.
@@ -73,7 +74,7 @@ public class InMemoryStorageService implements StorageService {
     }
 
     @Override
-    public void retrieveBook(String id, OnSuccessListener<Book> onSuccessListener, OnFailureListener onFailureListener) {
+    public void retrieveBook(EntityId id, OnSuccessListener<Book> onSuccessListener, OnFailureListener onFailureListener) {
         onSuccessListener.onSuccess(books.get(id));
     }
 
@@ -95,7 +96,7 @@ public class InMemoryStorageService implements StorageService {
 
     @Override
     public void retrieveBooksByRequester(User requester, OnSuccessListener<List<Book>> onSuccessListener, OnFailureListener onFailureListener) {
-        List<String> bookIds = new ArrayList<>();
+        List<EntityId> bookIds = new ArrayList<>();
         for (Request request : requests.values()) {
             bookIds.add(request.getBookId());
         }
@@ -121,7 +122,7 @@ public class InMemoryStorageService implements StorageService {
     }
 
     @Override
-    public void retrieveRequest(String id, OnSuccessListener<Request> onSuccessListener, OnFailureListener onFailureListener) {
+    public void retrieveRequest(EntityId id, OnSuccessListener<Request> onSuccessListener, OnFailureListener onFailureListener) {
         onSuccessListener.onSuccess(requests.get(id));
     }
 
@@ -153,11 +154,11 @@ public class InMemoryStorageService implements StorageService {
         onSuccessListener.onSuccess(null);
     }
 
-    private <T extends FirestoreIndexable> void storeEntity(Map<String, T> map, T entity) {
+    private <T extends FirestoreIndexable> void storeEntity(Map<EntityId, T> map, T entity) {
         if (entity.getId() != null) {
             map.put(entity.getId(), entity);
         } else {
-            map.put(UUID.randomUUID().toString(), entity);
+            map.put(new EntityId(), entity);
         }
     }
 }

--- a/src/app/src/main/java/com/example/bookmark/server/InMemoryStorageService.java
+++ b/src/app/src/main/java/com/example/bookmark/server/InMemoryStorageService.java
@@ -64,17 +64,6 @@ public class InMemoryStorageService implements StorageService {
     }
 
     @Override
-    public void retrieveBook(User owner, String isbn, OnSuccessListener<Book> onSuccessListener, OnFailureListener onFailureListener) {
-        for (Book book : books) {
-            if (book.getOwnerId().equals(owner.getId()) && book.getIsbn().equals(isbn)) {
-                onSuccessListener.onSuccess(book);
-                return;
-            }
-        }
-        onSuccessListener.onSuccess(null);
-    }
-
-    @Override
     public void retrieveBooks(OnSuccessListener<List<Book>> onSuccessListener, OnFailureListener onFailureListener) {
         onSuccessListener.onSuccess(books);
     }
@@ -114,17 +103,6 @@ public class InMemoryStorageService implements StorageService {
     @Override
     public void storeRequest(Request request, OnSuccessListener<Void> onSuccessListener, OnFailureListener onFailureListener) {
         requests.add(request);
-        onSuccessListener.onSuccess(null);
-    }
-
-    @Override
-    public void retrieveRequest(Book book, User requester, OnSuccessListener<Request> onSuccessListener, OnFailureListener onFailureListener) {
-        for (Request request : requests) {
-            if (request.getBookId().equals(book.getId()) && request.getRequesterId().equals(requester.getId())) {
-                onSuccessListener.onSuccess(request);
-                return;
-            }
-        }
         onSuccessListener.onSuccess(null);
     }
 

--- a/src/app/src/main/java/com/example/bookmark/server/InMemoryStorageService.java
+++ b/src/app/src/main/java/com/example/bookmark/server/InMemoryStorageService.java
@@ -7,7 +7,10 @@ import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 /**
  * An implementation of StorageProvider that stores all of the app's data in memory.
@@ -16,9 +19,9 @@ import java.util.List;
  * @author Kyle Hennig.
  */
 public class InMemoryStorageService implements StorageService {
-    private final List<User> users;
-    private final List<Book> books;
-    private final List<Request> requests;
+    private final Map<String, User> users = new HashMap<>();
+    private final Map<String, Book> books = new HashMap<>();
+    private final Map<String, Request> requests = new HashMap<>();
 
     /**
      * Creates an InMemoryStorageService.
@@ -35,20 +38,26 @@ public class InMemoryStorageService implements StorageService {
      * @param requests The requests that should exist to start.
      */
     public InMemoryStorageService(List<User> users, List<Book> books, List<Request> requests) {
-        this.users = users;
-        this.books = books;
-        this.requests = requests;
+        for (User user : users) {
+            storeEntity(this.users, user);
+        }
+        for (Book book : books) {
+            storeEntity(this.books, book);
+        }
+        for (Request request : requests) {
+            storeEntity(this.requests, request);
+        }
     }
 
     @Override
     public void storeUser(User user, OnSuccessListener<Void> onSuccessListener, OnFailureListener onFailureListener) {
-        users.add(user);
+        storeEntity(users, user);
         onSuccessListener.onSuccess(null);
     }
 
     @Override
     public void retrieveUserByUsername(String username, OnSuccessListener<User> onSuccessListener, OnFailureListener onFailureListener) {
-        for (User user : users) {
+        for (User user : users.values()) {
             if (user.getUsername().equals(username)) {
                 onSuccessListener.onSuccess(user);
                 return;
@@ -59,19 +68,24 @@ public class InMemoryStorageService implements StorageService {
 
     @Override
     public void storeBook(Book book, OnSuccessListener<Void> onSuccessListener, OnFailureListener onFailureListener) {
-        books.add(book);
+        storeEntity(books, book);
         onSuccessListener.onSuccess(null);
     }
 
     @Override
+    public void retrieveBook(String id, OnSuccessListener<Book> onSuccessListener, OnFailureListener onFailureListener) {
+        onSuccessListener.onSuccess(books.get(id));
+    }
+
+    @Override
     public void retrieveBooks(OnSuccessListener<List<Book>> onSuccessListener, OnFailureListener onFailureListener) {
-        onSuccessListener.onSuccess(books);
+        onSuccessListener.onSuccess(new ArrayList<>(books.values()));
     }
 
     @Override
     public void retrieveBooksByOwner(User owner, OnSuccessListener<List<Book>> onSuccessListener, OnFailureListener onFailureListener) {
         List<Book> booksByOwner = new ArrayList<>();
-        for (Book book : books) {
+        for (Book book : books.values()) {
             if (book.getOwnerId().equals(owner.getId())) {
                 booksByOwner.add(book);
             }
@@ -82,11 +96,11 @@ public class InMemoryStorageService implements StorageService {
     @Override
     public void retrieveBooksByRequester(User requester, OnSuccessListener<List<Book>> onSuccessListener, OnFailureListener onFailureListener) {
         List<String> bookIds = new ArrayList<>();
-        for (Request request : requests) {
+        for (Request request : requests.values()) {
             bookIds.add(request.getBookId());
         }
         List<Book> booksByRequester = new ArrayList<>();
-        for (Book book : books) {
+        for (Book book : books.values()) {
             if (bookIds.contains(book.getId())) {
                 booksByRequester.add(book);
             }
@@ -96,20 +110,25 @@ public class InMemoryStorageService implements StorageService {
 
     @Override
     public void deleteBook(Book book, OnSuccessListener<Void> onSuccessListener, OnFailureListener onFailureListener) {
-        books.remove(book);
+        books.remove(book.getId());
         onSuccessListener.onSuccess(null);
     }
 
     @Override
     public void storeRequest(Request request, OnSuccessListener<Void> onSuccessListener, OnFailureListener onFailureListener) {
-        requests.add(request);
+        storeEntity(requests, request);
         onSuccessListener.onSuccess(null);
+    }
+
+    @Override
+    public void retrieveRequest(String id, OnSuccessListener<Request> onSuccessListener, OnFailureListener onFailureListener) {
+        onSuccessListener.onSuccess(requests.get(id));
     }
 
     @Override
     public void retrieveRequestsByBook(Book book, OnSuccessListener<List<Request>> onSuccessListener, OnFailureListener onFailureListener) {
         List<Request> requestsByBook = new ArrayList<>();
-        for (Request request : requests) {
+        for (Request request : requests.values()) {
             if (request.getBookId().equals(book.getId())) {
                 requestsByBook.add(request);
             }
@@ -120,7 +139,7 @@ public class InMemoryStorageService implements StorageService {
     @Override
     public void retrieveRequestsByRequester(User requester, OnSuccessListener<List<Request>> onSuccessListener, OnFailureListener onFailureListener) {
         List<Request> requestsByRequester = new ArrayList<>();
-        for (Request request : requests) {
+        for (Request request : requests.values()) {
             if (request.getRequesterId().equals(requester.getId())) {
                 requestsByRequester.add(request);
             }
@@ -130,7 +149,15 @@ public class InMemoryStorageService implements StorageService {
 
     @Override
     public void deleteRequest(Request request, OnSuccessListener<Void> onSuccessListener, OnFailureListener onFailureListener) {
-        requests.remove(request);
+        requests.remove(request.getId());
         onSuccessListener.onSuccess(null);
+    }
+
+    private <T extends FirestoreIndexable> void storeEntity(Map<String, T> map, T entity) {
+        if (entity.getId() != null) {
+            map.put(entity.getId(), entity);
+        } else {
+            map.put(UUID.randomUUID().toString(), entity);
+        }
     }
 }

--- a/src/app/src/main/java/com/example/bookmark/server/StorageService.java
+++ b/src/app/src/main/java/com/example/bookmark/server/StorageService.java
@@ -42,6 +42,15 @@ public interface StorageService {
     void storeBook(Book book, OnSuccessListener<Void> onSuccessListener, OnFailureListener onFailureListener);
 
     /**
+     * Retrieves a book.
+     *
+     * @param id                The id of the book.
+     * @param onSuccessListener Callback to run on success.
+     * @param onFailureListener Callback to run on failure.
+     */
+    void retrieveBook(String id, OnSuccessListener<Book> onSuccessListener, OnFailureListener onFailureListener);
+
+    /**
      * Retrieves all the books.
      *
      * @param onSuccessListener Callback to run on success.
@@ -84,6 +93,15 @@ public interface StorageService {
      * @param onFailureListener Callback to run on failure.
      */
     void storeRequest(Request request, OnSuccessListener<Void> onSuccessListener, OnFailureListener onFailureListener);
+
+    /**
+     * Retrieves a request.
+     *
+     * @param id                The id of the request.
+     * @param onSuccessListener Callback to run on success.
+     * @param onFailureListener Callback to run on failure.
+     */
+    void retrieveRequest(String id, OnSuccessListener<Request> onSuccessListener, OnFailureListener onFailureListener);
 
     /**
      * Retrieves the requests for a book.

--- a/src/app/src/main/java/com/example/bookmark/server/StorageService.java
+++ b/src/app/src/main/java/com/example/bookmark/server/StorageService.java
@@ -42,16 +42,6 @@ public interface StorageService {
     void storeBook(Book book, OnSuccessListener<Void> onSuccessListener, OnFailureListener onFailureListener);
 
     /**
-     * Retrieves a book.
-     *
-     * @param owner             The owner of the book.
-     * @param isbn              The ISBN of the book.
-     * @param onSuccessListener Callback to run on success.
-     * @param onFailureListener Callback to run on failure.
-     */
-    void retrieveBook(User owner, String isbn, OnSuccessListener<Book> onSuccessListener, OnFailureListener onFailureListener);
-
-    /**
      * Retrieves all the books.
      *
      * @param onSuccessListener Callback to run on success.
@@ -94,16 +84,6 @@ public interface StorageService {
      * @param onFailureListener Callback to run on failure.
      */
     void storeRequest(Request request, OnSuccessListener<Void> onSuccessListener, OnFailureListener onFailureListener);
-
-    /**
-     * Retrieves a request.
-     *
-     * @param book              The book the request was for.
-     * @param requester         The user who made the request.
-     * @param onSuccessListener Callback to run on success.
-     * @param onFailureListener Callback to run on failure.
-     */
-    void retrieveRequest(Book book, User requester, OnSuccessListener<Request> onSuccessListener, OnFailureListener onFailureListener);
 
     /**
      * Retrieves the requests for a book.

--- a/src/app/src/main/java/com/example/bookmark/server/StorageService.java
+++ b/src/app/src/main/java/com/example/bookmark/server/StorageService.java
@@ -1,6 +1,7 @@
 package com.example.bookmark.server;
 
 import com.example.bookmark.models.Book;
+import com.example.bookmark.models.EntityId;
 import com.example.bookmark.models.Request;
 import com.example.bookmark.models.User;
 import com.google.android.gms.tasks.OnFailureListener;
@@ -48,7 +49,7 @@ public interface StorageService {
      * @param onSuccessListener Callback to run on success.
      * @param onFailureListener Callback to run on failure.
      */
-    void retrieveBook(String id, OnSuccessListener<Book> onSuccessListener, OnFailureListener onFailureListener);
+    void retrieveBook(EntityId id, OnSuccessListener<Book> onSuccessListener, OnFailureListener onFailureListener);
 
     /**
      * Retrieves all the books.
@@ -101,7 +102,7 @@ public interface StorageService {
      * @param onSuccessListener Callback to run on success.
      * @param onFailureListener Callback to run on failure.
      */
-    void retrieveRequest(String id, OnSuccessListener<Request> onSuccessListener, OnFailureListener onFailureListener);
+    void retrieveRequest(EntityId id, OnSuccessListener<Request> onSuccessListener, OnFailureListener onFailureListener);
 
     /**
      * Retrieves the requests for a book.

--- a/src/app/src/main/java/com/example/bookmark/util/UserUtil.java
+++ b/src/app/src/main/java/com/example/bookmark/util/UserUtil.java
@@ -3,8 +3,6 @@ package com.example.bookmark.util;
 import android.content.Context;
 import android.content.SharedPreferences;
 
-import static android.content.Context.MODE_PRIVATE;
-
 /**
  * This class implements utility functions to set and retrieve the logged in user
  *


### PR DESCRIPTION
- Book ids and request ids no longer contain input from the user.
- Ids are now generated using version 4 UUIDs.
- Since usernames are impossible to change and we display them quite frequently, user's still use their username as an id.